### PR TITLE
Change Open token address to Mainnet

### DIFF
--- a/frontend/src/const/open.js
+++ b/frontend/src/const/open.js
@@ -1,4 +1,4 @@
-export const OPEN_ADDRESS = '0xD57B27f6ebA186D56ec2AaaF9BbB438678DFd4f1';
+export const OPEN_ADDRESS = '0x9d86b1b2554ec410eccffbf111a6994910111340';
 export const OPEN_ABI = [
   {
     constant: true,


### PR DESCRIPTION
Changed Open token address from Rinkeby to Mainnet Ethereum network.
In my case, Activating Scaffold in Ethereum Main Net is now not available. 
To deploy scaffold is required to choose only Main Ethereum Network. Rinkeby Testnet is not available.

![Screenshort](https://user-images.githubusercontent.com/40195312/61790971-6e195180-ae3a-11e9-9a95-0350fa0bdbd0.jpg)
